### PR TITLE
Module changes for Agility 2021 lab

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -251,4 +251,5 @@ resource google_compute_instance f5vm01 {
   provisioner "local-exec" {
     command = "sleep 100"
   }
+  labels   = var.labels
 }

--- a/main.tf
+++ b/main.tf
@@ -132,20 +132,21 @@ data "google_secret_manager_secret_version" "secret" {
 }
 
 resource "google_service_account" "sa" {
+  count = var.service_account != "" ? 0 : 1
   account_id   = format("%s", random_string.sa_role.result)
   display_name = format("%s", random_string.sa_role.result)
   description = "Service accounts for GCP IAM authentication"
 }
 
 resource "google_project_iam_member" "gcp_role_member_assignment" {
-  count   = var.gcp_secret_manager_authentication ? 1 : 0
+  count   = var.gcp_secret_manager_authentication && length(google_service_account.sa) > 0 ? 1 : 0
   project = var.project_id
   role    = format("projects/${var.project_id}/roles/%s",random_string.sa_role.result)
-  member  = "serviceAccount:${google_service_account.sa.email}"
+  member  = "serviceAccount:${google_service_account.sa.0.email}"
 }
 
 resource "google_project_iam_custom_role" "gcp_custom_roles" {
-  count       = var.gcp_secret_manager_authentication ? 1 : 0
+  count       = var.gcp_secret_manager_authentication && length(google_service_account.sa) > 0 ? 1 : 0
   role_id     = random_string.sa_role.result
   title       = random_string.sa_role.result
   description = "IAM for authentication"
@@ -182,7 +183,7 @@ resource google_compute_instance f5vm01 {
     }
   }
   service_account {
-    email  = google_service_account.sa.email
+    email  = element(coalescelist([var.service_account], google_service_account.sa.*.email), 0)
     scopes = ["cloud-platform"]
   }
   can_ip_forward = true

--- a/main.tf
+++ b/main.tf
@@ -14,77 +14,78 @@ resource random_id module_id {
 }
 
 locals {
-  bigip_map = {
-    "mgmt_subnet_ids"     = var.mgmt_subnet_ids
-    "external_subnet_ids" = var.external_subnet_ids
-    "internal_subnet_ids" = var.internal_subnet_ids
-  }
-  mgmt_public_subnet_id = [
-    for subnet in local.bigip_map["mgmt_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == true
-  ]
-  mgmt_private_subnet_id = [
-    for subnet in local.bigip_map["mgmt_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == false
-  ]
-  mgmt_public_private_ip_primary = [
-    for private in local.bigip_map["mgmt_subnet_ids"] :
-    private["private_ip_primary"]
-    if private["public_ip"] == true
-  ]
-  mgmt_private_ip_primary = [
-    for private in local.bigip_map["mgmt_subnet_ids"] :
-    private["private_ip_primary"]
-    if private["public_ip"] == false
-  ]
-  external_public_subnet_id = [
-    for subnet in local.bigip_map["external_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == true
-  ]
-  external_private_subnet_id = [
-    for subnet in local.bigip_map["external_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == false
-  ]
-  internal_public_subnet_id = [
-    for subnet in local.bigip_map["internal_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == true
-  ]
-  internal_private_subnet_id = [
-    for subnet in local.bigip_map["internal_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == false
-  ]
-  internal_private_ip_primary = [
-    for private in local.bigip_map["internal_subnet_ids"] :
-    private["private_ip_primary"]
-    if private["public_ip"] == false
-  ]
-  external_private_ip_primary = [
-    for private in local.bigip_map["external_subnet_ids"] :
-    private["private_ip_primary"]
-    if private["public_ip"] == false
-  ]
-  external_private_ip_secondary = [
-    for private in local.bigip_map["external_subnet_ids"] :
-    private["private_ip_secondary"]
-    if private["public_ip"] == false
-  ]
-  external_public_private_ip_primary = [
-    for private in local.bigip_map["external_subnet_ids"] :
-    private["private_ip_primary"]
-    if private["public_ip"] == true
-  ]
-  external_public_private_ip_secondary = [
-    for private in local.bigip_map["external_subnet_ids"] :
-    private["private_ip_secondary"]
-    if private["public_ip"] == true
-  ]
-  total_nics      = length(concat(local.mgmt_public_subnet_id, local.mgmt_private_subnet_id, local.external_public_subnet_id, local.external_private_subnet_id, local.internal_public_subnet_id, local.internal_private_subnet_id))
+  # Emes - none of this commented section should be needed
+  # bigip_map = {
+  #   "mgmt_subnet_ids"     = var.mgmt_subnet_ids
+  #   "external_subnet_ids" = var.external_subnet_ids
+  #   "internal_subnet_ids" = var.internal_subnet_ids
+  # }
+  # mgmt_public_subnet_id = [
+  #   for subnet in local.bigip_map["mgmt_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == true
+  # ]
+  # mgmt_private_subnet_id = [
+  #   for subnet in local.bigip_map["mgmt_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == false
+  # ]
+  # mgmt_public_private_ip_primary = [
+  #   for private in local.bigip_map["mgmt_subnet_ids"] :
+  #   private["private_ip_primary"]
+  #   if private["public_ip"] == true
+  # ]
+  # mgmt_private_ip_primary = [
+  #   for private in local.bigip_map["mgmt_subnet_ids"] :
+  #   private["private_ip_primary"]
+  #   if private["public_ip"] == false
+  # ]
+  # external_public_subnet_id = [
+  #   for subnet in local.bigip_map["external_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == true
+  # ]
+  # external_private_subnet_id = [
+  #   for subnet in local.bigip_map["external_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == false
+  # ]
+  # internal_public_subnet_id = [
+  #   for subnet in local.bigip_map["internal_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == true
+  # ]
+  # internal_private_subnet_id = [
+  #   for subnet in local.bigip_map["internal_subnet_ids"] :
+  #   subnet["subnet_id"]
+  #   if subnet["public_ip"] == false
+  # ]
+  # internal_private_ip_primary = [
+  #   for private in local.bigip_map["internal_subnet_ids"] :
+  #   private["private_ip_primary"]
+  #   if private["public_ip"] == false
+  # ]
+  # external_private_ip_primary = [
+  #   for private in local.bigip_map["external_subnet_ids"] :
+  #   private["private_ip_primary"]
+  #   if private["public_ip"] == false
+  # ]
+  # external_private_ip_secondary = [
+  #   for private in local.bigip_map["external_subnet_ids"] :
+  #   private["private_ip_secondary"]
+  #   if private["public_ip"] == false
+  # ]
+  # external_public_private_ip_primary = [
+  #   for private in local.bigip_map["external_subnet_ids"] :
+  #   private["private_ip_primary"]
+  #   if private["public_ip"] == true
+  # ]
+  # external_public_private_ip_secondary = [
+  #   for private in local.bigip_map["external_subnet_ids"] :
+  #   private["private_ip_secondary"]
+  #   if private["public_ip"] == true
+  # ]
+  # total_nics      = length(concat(local.mgmt_public_subnet_id, local.mgmt_private_subnet_id, local.external_public_subnet_id, local.external_private_subnet_id, local.internal_public_subnet_id, local.internal_private_subnet_id))
   instance_prefix = format("%s-%s", var.prefix, random_id.module_id.hex)
 }
 
@@ -155,11 +156,11 @@ resource "google_project_iam_custom_role" "gcp_custom_roles" {
 
 
 resource google_compute_address mgmt_public_ip {
-  count = length(local.mgmt_public_subnet_id)
+  count = length([for address in compact([for subnet in var.mgmt_subnet_ids: subnet.public_ip]): address if address])
   name  = format("%s-mgmt-publicip-%s", var.prefix, random_id.module_id.hex)
 }
 resource google_compute_address external_public_ip {
-  count = length(local.external_public_subnet_id)
+  count = length([for address in compact([for subnet in var.external_subnet_ids: subnet.public_ip]): address if address])
   name  = format("%s-ext-publicip-%s-%s", var.prefix, count.index, random_id.module_id.hex)
 }
 
@@ -187,67 +188,57 @@ resource google_compute_instance f5vm01 {
     scopes = ["cloud-platform"]
   }
   can_ip_forward = true
-  #Assign Public IP to Management Nic
+  #Assign to Management Nic
   dynamic network_interface {
-    for_each = local.mgmt_public_subnet_id
+    for_each = [for subnet in var.mgmt_subnet_ids: subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
-      subnetwork = network_interface.value
-      access_config {
-        nat_ip = google_compute_address.mgmt_public_ip[tonumber(network_interface.key)].address
+      subnetwork = network_interface.value.subnet_id
+      network_ip = network_interface.value.private_ip_primary
+      dynamic access_config {
+        for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []
+        content {
+          nat_ip = google_compute_address.mgmt_public_ip[tonumber(network_interface.key)].address
+        }
       }
-    }
-  }
-  dynamic network_interface {
-    for_each = local.mgmt_private_subnet_id
-    content {
-      subnetwork = network_interface.value
-      network_ip = local.mgmt_private_ip_primary[tonumber(network_interface.key)]
-      //network_ip = length(local.mgmt_private_ip_primary) > 0 ? local.mgmt_private_ip_primary[0]: ""
     }
   }
 
-  #Assign Public IP to external Nic
+  #Assign external Nic
   dynamic network_interface {
-    for_each = local.external_public_subnet_id
+    for_each = [for subnet in var.external_subnet_ids: subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
-      subnetwork = network_interface.value
-      access_config {
-        nat_ip = google_compute_address.external_public_ip[tonumber(network_interface.key)].address
+      subnetwork = network_interface.value.subnet_id
+      network_ip = network_interface.value.private_ip_primary
+      dynamic access_config {
+        for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []
+        content {
+          nat_ip = google_compute_address.external_public_ip[tonumber(network_interface.key)].address
+        }
       }
-      alias_ip_range {
-        ip_cidr_range = local.external_public_private_ip_secondary[tonumber(network_interface.key)] != "" ? local.external_public_private_ip_secondary[tonumber(network_interface.key)] : "/32"
-      }
-    }
-  }
-  #Create External NIC with Private IP Static/Dynamic
-  dynamic network_interface {
-    for_each = local.external_private_subnet_id
-    content {
-      subnetwork = network_interface.value
-      network_ip = local.external_private_ip_primary[tonumber(network_interface.key)]
-      alias_ip_range {
-        ip_cidr_range = local.external_private_ip_secondary[tonumber(network_interface.key)] != "" ? local.external_private_ip_secondary[tonumber(network_interface.key)] : "/32"
+      dynamic alias_ip_range {
+        for_each = compact([network_interface.value.private_ip_secondary])
+        content {
+          ip_cidr_range = alias_ip_range.value
+        }
       }
     }
   }
+  
+  # Internal NIC
   dynamic network_interface {
-    for_each = local.internal_public_subnet_id
+    for_each = [for subnet in var.internal_subnet_ids: subnet if subnet.subnet_id != null && subnet.subnet_id != ""]
     content {
-      subnetwork = network_interface.value
-      network_ip = local.internal_public_private_ip_primary[tonumber(network_interface.key)]
-      //network_ip = length(local.internal_public_private_ip_primary) > 0 ? local.internal_public_private_ip_primary[0]: ""
-      access_config {
+      subnetwork = network_interface.value.subnet_id
+      network_ip = network_interface.value.private_ip_primary
+      dynamic access_config {
+        for_each = element(coalescelist(compact([network_interface.value.public_ip]), [false]), 0) ? [1] : []
+        content {
+          nat_ip = google_compute_address.internal_public_ip[tonumber(network_interface.key)].address
+        }
       }
     }
   }
-  #Create Internal Nic with Dynamic Private IP/Static Private IP
-  dynamic network_interface {
-    for_each = local.internal_private_subnet_id
-    content {
-      subnetwork = network_interface.value
-      network_ip = local.internal_private_ip_primary[tonumber(network_interface.key)]
-    }
-  }
+
   metadata_startup_script = data.template_file.startup_script.rendered
   provisioner "local-exec" {
     command = "sleep 100"

--- a/main.tf
+++ b/main.tf
@@ -140,14 +140,14 @@ resource "google_service_account" "sa" {
 }
 
 resource "google_project_iam_member" "gcp_role_member_assignment" {
-  count   = var.gcp_secret_manager_authentication && length(google_service_account.sa) > 0 ? 1 : 0
+  count   = var.gcp_secret_manager_authentication && var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = format("projects/${var.project_id}/roles/%s",random_string.sa_role.result)
   member  = "serviceAccount:${google_service_account.sa.0.email}"
 }
 
 resource "google_project_iam_custom_role" "gcp_custom_roles" {
-  count       = var.gcp_secret_manager_authentication && length(google_service_account.sa) > 0 ? 1 : 0
+  count       = var.gcp_secret_manager_authentication && var.service_account == "" ? 1 : 0
   role_id     = random_string.sa_role.result
   title       = random_string.sa_role.result
   description = "IAM for authentication"

--- a/output.tf
+++ b/output.tf
@@ -18,3 +18,6 @@ output private_addresses {
   value = [google_compute_instance.f5vm01.network_interface[*].network_ip]
 }
 
+output service_account {
+  value = google_service_account.sa.email
+}

--- a/output.tf
+++ b/output.tf
@@ -3,7 +3,7 @@ output mgmtPublicIP {
 }
 output mgmtPort {
   description = "Mgmt Port"
-  value       = local.total_nics > 1 ? "443" : "8443"
+  value       = length(google_compute_instance.f5vm01.network_interface) > 1 ? "443" : "8443"
 }
 output f5_username {
   value = var.f5_username

--- a/output.tf
+++ b/output.tf
@@ -19,5 +19,5 @@ output private_addresses {
 }
 
 output service_account {
-  value = google_service_account.sa.email
+  value = element(coalescelist([var.service_account], google_service_account.sa.*.email), 0)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -169,3 +169,8 @@ variable INIT_URL {
   type        = string
   default     = "https://cdn.f5.com/product/cloudsolutions/f5-bigip-runtime-init/v1.2.0/dist/f5-bigip-runtime-init-1.2.0-1.gz.run"
 }
+
+variable labels {
+  description = "An optional map of key:value labels to add to the instance"
+  type        = map(string)
+  default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -174,3 +174,10 @@ variable labels {
   description = "An optional map of key:value labels to add to the instance"
   type        = map(string)
   default     = {}
+}
+
+variable service_account {
+  description = "Optional service account email to use with BIG-IP. If left blank (default), a service account will be generated."
+  type = string
+  default = ""
+}


### PR DESCRIPTION
The GCP Agility team want to use this BIG-IP module for a student lab, but there are problems when trying to enable public and private IP addresses. For the lab, we must be able to assign known private IP addresses to each of management, external, and internal NICs, as well as expose management and external NICs with public IP addresses. In addition, a CIDR that is not `/32` is required on one instance that will be used for VIPs.

In addition, the module should allow the VMs to be labeled for CFE and other use-cases.

Finally, we want to use the same service account for both BIG-IP VMs used by a student.

## Sample Terraform
```hcl
module "bigip_1" {
  ...
  labels = {
    my-label = "my-value"
  }
  service_account = "my-sa@my-project.iam.gserviceaccount.com"
  mgmt_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.mgmt.self_link
      public_ip = true
      private_ip_primary = "172.17.100.1"
    },
  ]
  external_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.external.self_link
      public_ip = true
      private_ip_primary = "172.16.100.1"
      private_ip_secondary = "172.16.0.128/29"
    },
  ]
  internal_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.internal.self_link
      public_ip = false
      private_ip_primary = "172.18.100.1"
    },
  ]
}

module "bigip_2" {
  ...
  labels = {
    my-label = "my-value"
  }
  service_account = "my-sa@my-project.iam.gserviceaccount.com"
  mgmt_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.mgmt.self_link
      public_ip = true
      private_ip_primary = "172.17.100.2"
      private_ip_secondary = ""
    },
  ]
  external_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.external.self_link
      public_ip = true
      private_ip_primary = "172.16.100.2"
      private_ip_secondary = ""
    },
  ]
  internal_subnet_ids = [
    {
      subnet_id = data.google_compute_subnetwork.internal.self_link
      public_ip = false
      private_ip_primary = "172.18.100.2"
    },
  ]
}
```

## Results

| VM | iface | expected | base repo module | forked repo module |
|----|------|-----------|------------|--------------|
|1|mgmt|*172.17.100.1*|172.17.0.3 :x:|172.17.100.1 :heavy_check_mark:|
|1|external (IP)|*172.16.100.1*|172.16.0.4 :x:|172.16.100.1 :heavy_check_mark:|
|1|external (VIP)|*172.16.0.128/29*|172.16.0.128/29 :heavy_check_mark:|172.16.0.128/29 :heavy_check_mark:|
|1|internal|*172.18.100.1*|172.18.100.1 :heavy_check_mark:|172.18.100.1 :heavy_check_mark:|
|2|mgmt|*172.17.100.2*|172.17.0.2 :x:|172.17.100.2 :heavy_check_mark:|
|2|external (IP)|*172.16.100.2*|172.16.0.3 :x:|172.16.100.2 :heavy_check_mark:|
|2|external (VIP)|*unassigned*|172.16.0.2/32 :x:| :heavy_check_mark:|
|2|internal|172.18.100.2|172.18.100.2 :heavy_check_mark:|172.18.100.2 :heavy_check_mark:|

# Proposed changes in this PR

## Additional inputs
* `labels`: map of key:value label pairs to apply to BIG-IP VM
* `service_account`: email of an *existing* GCP service account to use with BIG-IP VM. If a service account email is provided by the module user, then the creation of in-module service account and custom role will be skipped. It is module consumer's responsibility to setup service account appropriately.

## Additional outputs
* `service_account`: the email address of the GCP service account being used by BIG-IP VM (generated or supplied)

## Refactored
* Reworked address assignment to NICs
   * GCP doesn't use separate NICs for private/public addresses; public is simply `nat_ip` option on the NIC
   * Don't force append `/32` to Alias IPs - they are CIDRs not IPv4 addresses

## Testing matrix

1. Terraform 0.14 - init/apply/destroy
   1. all provided examples without change
   2. all provided examples with GCP secret manager enabled and secret ID provided
   3. Agility 2021 GCP lab with provided service account and GCP Secret Manager  (see https://github.com/memes/Agility2021_GCP_Terraform_ATC/blob/main/main.tf) 
2. Terraform 0.13 - init/apply/destroy
   1. all provided examples without change
   2. all provided examples with GCP secret manager enabled and secret ID provided
   3. Agility 2021 GCP lab with provided service account and GCP Secret Manager (see https://github.com/memes/Agility2021_GCP_Terraform_ATC/blob/main/main.tf)