### PR TITLE
Support Google provider >= 3.51.0, < 4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.51.0"
+      version = "~> 3.51"
     }
   }
 }


### PR DESCRIPTION
Proposed fix to close #14

Allow use of Google providers with major version 3, that is at least 3.51.0 using ~> constraint.