### PR TITLE
Additional module outputs: self_link, name, and zone

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -26,3 +26,13 @@ output self_link {
   value = google_compute_instance.f5vm01.self_link
   description = "Fully-qualifed self-link of the BIG-IP VM."
 }
+
+output name {
+  value = google_compute_instance.f5vm01.name
+  description = "The final instance name for BIG-IP VM."
+}
+
+output zone {
+  value = google_compute_instance.f5vm01.zone
+  description = "The compute zone for the instance."
+}


### PR DESCRIPTION
Proposed fix to close #16.

Add the following outputs to the module:-

## Important

* `self_link` globally unique identifier for the generated VM
* `name` generated name assigned to the VM (unique within project)

## Nice to have
* `zone` return the VM zone; useful when the customer is calling module in a for_each loop with zones