### PR TITLE
Allow module user to provide a true user-data input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,10 +252,10 @@ resource google_compute_instance f5vm01 {
 
   metadata_startup_script = coalesce(var.custom_user_data,data.template_file.startup_script.rendered)
 
-  metadata = {
-
+  metadata = merge(var.metadata, coalesce(var.f5_ssh_publickey, "unspecified") != "unspecified" ? {
     sshKeys = file(var.f5_ssh_publickey)
-  }
+    } : {}
+  )
 
   provisioner "local-exec" {
     command = "sleep 250"

--- a/variables.tf
+++ b/variables.tf
@@ -192,3 +192,9 @@ variable custom_user_data {
   default     = null
 }
 
+variable metadata {
+  description = "Provide custom metadata values for BIG-IP instance"
+  type        = map(string)
+  default     = {}
+}
+


### PR DESCRIPTION
Proposed fix to close #20 

## Proposed least invasive solution
* Add a **new** variable `metadata` that will become the base set of metadata key:value pairs for the instance

## Example usage

```hcl
module "bigips" {
   ...
   # Onboard through cloud-config YAML and allow connection to serial port
  metadata = {
    user-data = var.cloud_config_yaml
    serial-port-enable = "TRUE"
  }
  
  # Override the module startup-script as everything is in cloud-config YAML
  custom_user_data = <<-EOS
#!/bin/sh
exit 0
EOS
}
```